### PR TITLE
improved prompt input card behavior and styling

### DIFF
--- a/shadcnFrontend/src/App.css
+++ b/shadcnFrontend/src/App.css
@@ -126,7 +126,8 @@ h2 {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin: 1.5rem 0;
+  margin: 0;
+  height: 38px; /* Match button height */
   opacity: 0;
   transform: scale(0.95);
   animation: fadeInScale 0.6s ease-in-out forwards;

--- a/shadcnFrontend/src/App.tsx
+++ b/shadcnFrontend/src/App.tsx
@@ -550,12 +550,9 @@ function App() {
             )}
 
             {/* Prompt Input Card */}
-            <Card className="text-left">
-              <CardHeader>
-                <CardTitle className="text-[#F4B400]">Enter prompt</CardTitle>
-              </CardHeader>
+            <Card className="text-left space-y-4">
               <CardContent>
-                <form onSubmit={handleSubmit}>
+                <form onSubmit={handleSubmit} className="flex flex-col space-y-4">
                   <Textarea
                     placeholder="Describe your IAM policy requirements in plain English..."
                     value={prompt}
@@ -578,7 +575,7 @@ function App() {
                     className="prompt-input"
                     style={{ borderColor: "#4285F4" }}
                   />
-                  <div className="py-2.5 flex justify-center">
+                  <div className="flex items-center justify-center" style={{ minHeight: '60px' }}>
                     {showLoadingAnimation ? (
                       <div className={`loading-container ${fadeOutLoading ? 'fade-out' : ''}`}>
                         <div className="loading-text">Generating your policy</div>


### PR DESCRIPTION
- Added a GCP styled loading animation for policy generation
- 'Generate Policy' button has two possible behaviors after a successful policy generation, either confirms successful generation and becomes inactive, or instructs user to rewrite prompt based on chat feedback if generation failed.
- Removed 'Enter Prompt' heading from the input card, does not feel necessary with the current placeholder text
- Adjusted padding/margins to avoid card resizing while user is interacting with it